### PR TITLE
Fix for issue #97 (trouble viewing a second channel in .annot files)

### DIFF
--- a/src/annot/annot.py
+++ b/src/annot/annot.py
@@ -398,7 +398,7 @@ class Annotations(QObject):
                     to_activate.append(line)
                     line = f.readline().strip()
                 found_annotation_names = True
-            elif line.lower().startswith("ch"):
+            elif line.strip().lower().endswith("---"):
                 for ch_name in channel_names:
                     if line.startswith(ch_name):
                         self._channels[ch_name] = Channel()


### PR DESCRIPTION
The problem was my second channel didn't begin with "ch"- so I modified annotation loading code to recognize more general channel names.