### PR TITLE
Disable incomplete support for .csv pose files

### DIFF
--- a/src/plugin/plugin_pose_DeepLabCut.py
+++ b/src/plugin/plugin_pose_DeepLabCut.py
@@ -131,7 +131,7 @@ class PoseDLC_generic(PoseBase):
         return "DeepLabCut geenric pose files"
 
     def getFileSearchPattern(self) -> str:
-        return "*.h5, *.csv"
+        return "*.h5"
 
     def getFileFormat(self) -> str:
         return "DeepLabCut_generic"


### PR DESCRIPTION
This is to address issue #134, by disabling support for .csv files, which will come with DeepLabCut generic pose file support.