### PR TITLE
Change starting path to find plugin directory

### DIFF
--- a/src/pose/pose.py
+++ b/src/pose/pose.py
@@ -83,7 +83,7 @@ class PoseRegistry():
         Import any that are found, and call their "register" function if there is one
         If no "register" function exists, the plugin will not be available for use.
         """
-        plugin_dir = curdir
+        plugin_dir = sys.path[0]
         if 'src' in listdir(plugin_dir):
             plugin_dir += sep + 'src'
         if 'plugin' in listdir(plugin_dir):


### PR DESCRIPTION
From curdir to sys.path[0] (directory of file that started the python interpreter)

As we thought, this fix was easy.  Venus, please review. (It's a trivial change that shouldn't need review, but our repository rules require a review before merging is allowed.)